### PR TITLE
Fixing path to csproj file in build in workflow.

### DIFF
--- a/.github/workflows/main_bdsagroup30chirpremotedb.yml
+++ b/.github/workflows/main_bdsagroup30chirpremotedb.yml
@@ -22,10 +22,10 @@ jobs:
           dotnet-version: '8.x'
 
       - name: Build with dotnet
-        run: dotnet build Chirp.csproj --configuration Release --runtime linux-x64
+        run: dotnet build src/Chirp.csproj --configuration Release --runtime linux-x64
 
       - name: dotnet publish
-        run: dotnet publish Chirp.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        run: dotnet publish src/Chirp.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Path in workflow file was wrong. Was Chirp.csproj is now src/Chirp.csproj

Co-authored-by: Sophie Gabriela <slak@itu.dk>