### PR TITLE
Merge this AFTER Ordering of Cheeps: Two ("three") API tests added in Chirp.ChirpWeb.Tests

### DIFF
--- a/src/ChirpWeb/ChirpWeb.csproj
+++ b/src/ChirpWeb/ChirpWeb.csproj
@@ -32,6 +32,8 @@
     <ProjectReference Include="../ChirpInfrastructure/ChirpInfrastructure.csproj"/>
     <ProjectReference Include="../ChirpCore/ChirpCore.csproj"/>
 
+    <InternalsVisibleTo Include="Chirp.ChirpWeb.Tests" />
+
   </ItemGroup>
 
 </Project>

--- a/src/ChirpWeb/Program.cs
+++ b/src/ChirpWeb/Program.cs
@@ -75,4 +75,6 @@ using (var scope = app.Services.CreateScope())
 }
 
 app.Run();
-//public partial class Program { }
+
+//class for API tests in Chirp.ChirpWeb.Tests
+public partial class Program { }

--- a/test/Chirp.ChirpWeb.Tests/API_Tests.cs
+++ b/test/Chirp.ChirpWeb.Tests/API_Tests.cs
@@ -1,0 +1,59 @@
+using Xunit;
+using ChirpWeb;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.VisualStudio.TestPlatform.TestHost;
+
+namespace Chirp.ChirpWeb.Tests{
+
+public class APITests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _fixture;
+    private readonly HttpClient _client;
+
+
+	public APITests(WebApplicationFactory<Program> fixture)
+    {
+        _fixture = fixture;
+        _client = _fixture.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = true, HandleCookies = true });
+    }
+
+    [Fact]
+    public async void CanSeePublicTimeline()
+    {
+        var response = await _client.GetAsync("/");
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+
+        Assert.Contains("Chirp!", content);
+        Assert.Contains("Public Timeline", content);
+    }
+
+    [Theory]
+    [InlineData("Luanna Muro")]
+    public async void CanSeePrivateTimeline(string author)
+    {
+        var response = await _client.GetAsync($"/{author}");
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+
+        Assert.Contains("Chirp!", content);
+        Assert.Contains($"{author}'s Timeline", content);
+       
+    }
+    /*Data NOT included in these API tests (write statements shows in commandline
+    that no cheeps are visible. Fix and test more, or simply test this somehow else?)
+    [Theory]
+    [InlineData("Luanna Muro")]
+    public async void PrivateTimelineContainsCheep(string author) {
+        var response = await _client.GetAsync($"/{author}");
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+        Console.WriteLine(content);
+        //check that we are still on correct timeline
+        Assert.Contains($"{author}'s Timeline", content);
+
+        //check that an expected Cheep exists
+        Assert.Contains("Of all the sailors called them ring-bolts, and would lay my hand into the wind''s eye.", content);
+    }*/
+}
+}

--- a/test/Chirp.ChirpWeb.Tests/API_Tests.cs
+++ b/test/Chirp.ChirpWeb.Tests/API_Tests.cs
@@ -10,13 +10,14 @@ public class APITests : IClassFixture<WebApplicationFactory<Program>>
     private readonly WebApplicationFactory<Program> _fixture;
     private readonly HttpClient _client;
 
-
+    //constructor taken from week 5 slides
 	public APITests(WebApplicationFactory<Program> fixture)
     {
         _fixture = fixture;
         _client = _fixture.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = true, HandleCookies = true });
     }
 
+    //test mostly taken from week 5 slides
     [Fact]
     public async void CanSeePublicTimeline()
     {
@@ -28,6 +29,7 @@ public class APITests : IClassFixture<WebApplicationFactory<Program>>
         Assert.Contains("Public Timeline", content);
     }
 
+    //test mostly taken from week 5 slides
     [Theory]
     [InlineData("Luanna Muro")]
     public async void CanSeePrivateTimeline(string author)
@@ -40,6 +42,7 @@ public class APITests : IClassFixture<WebApplicationFactory<Program>>
         Assert.Contains($"{author}'s Timeline", content);
        
     }
+    
     /*Data NOT included in these API tests (write statements shows in commandline
     that no cheeps are visible. Fix and test more, or simply test this somehow else?)
     [Theory]

--- a/test/Chirp.ChirpWeb.Tests/Chirp.ChirpWeb.Tests.csproj
+++ b/test/Chirp.ChirpWeb.Tests/Chirp.ChirpWeb.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -7,10 +7,12 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />


### PR DESCRIPTION
Two are running and work (get public timeline, get private timeline), but one is commented out as data seems not to be transfered to the instance we use for testing. I can look at this more later, but think we might have other tests later that will also test this, so maybe unnescesary work.