### PR TITLE
Update to ubuntu-latest-22.04

### DIFF
--- a/.github/workflows/automaticlabels.yaml
+++ b/.github/workflows/automaticlabels.yaml
@@ -9,7 +9,7 @@ on:
       - opened
 jobs:
   label_issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-22.04
     permissions:
       issues: write
     steps:

--- a/.github/workflows/build-and-test-dotnet.yml
+++ b/.github/workflows/build-and-test-dotnet.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/main_bdsagroup30chirpremotedb.yml
+++ b/.github/workflows/main_bdsagroup30chirpremotedb.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
           path: ${{env.DOTNET_ROOT}}/myapp
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-22.04
     needs: build
     environment:
       name: 'Production'


### PR DESCRIPTION
**2/2 pull request**
**Starting 5th december 2024 to 17 January 2025,** ubuntu-latest will be using ubuntu-latest-22.04 for ubuntu24.04 image.

Link: https://github.com/actions/runner-images/issues/10636